### PR TITLE
datos en planilla GSheets con series SOCHIMI e inicio de síntomas

### DIFF
--- a/datos/README.md
+++ b/datos/README.md
@@ -18,7 +18,8 @@ Cuando subas una base de datos, por favor incluye en la lista de contribuciones,
 
  1. **[Datos CoVID-19 Ministerio Ciencias](http://www.minciencia.gob.cl/covid19)**: Datos epidemiológicos provenientes del Ministerio de Salud. Descripción de datos en link.
  2. **[Portal datos público Chile](http://datos.gob.cl/)**: Datos públicos de gobierno, potencialmente útiles para modelación (e.g., encuesta origen-destino). 
- 3.  **[Jorge_Perez](https://github.com/jorgeperezrojas/covid19-data)**: Recopilación datos CoVID-19 en Chile desde varias fuentes.
- 4. **[IvanMSC](https://github.com/ivanMSC/COVID19_Chile)**: Datos CoVID-19 actualizados Chile y [Latinoamerica](https://github.com/DataScienceResearchPeru/covid-19_latinoamerica).
- 5.  **[Cuarentenas](https://docs.google.com/spreadsheets/d/1IjirW9zoW5H-x8AnQcQaKXZXiS1tCuTs0PxSkNxYE0g/edit#gid=0)**: Planilla resumen cuarentenas y cordones sanitarios en Chile.
+ 3.  **[Jorge_Perez - Github](https://github.com/jorgeperezrojas/covid19-data)**: Recopilación datos CoVID-19 en Chile desde varias fuentes.
+ 4.  **[Jorge_Perez - GSheets](https://github.com/jorgeperezrojas/covid19-data)**: Varios datos formateados incluyendo [Encuesta Sochimi](https://www.medicina-intensiva.cl/site/post.php?id=1000328&sec=9) ([`tab en la planilla`](https://docs.google.com/spreadsheets/d/1mLx2L8nMaRZu0Sy4lyFniDewl6jDcgnxB_d0lHG-boc/edit#gid=267863881)), y serie de tiempo de datos de **inicio de síntomas diarios** y **pacientes notificados en Epivigila** ([`tab en la planilla`](https://docs.google.com/spreadsheets/d/1mLx2L8nMaRZu0Sy4lyFniDewl6jDcgnxB_d0lHG-boc/edit#gid=1170070241)) (Al parecer es la única fuente pública con estas dos series tabuladas).
+ 5. **[IvanMSC](https://github.com/ivanMSC/COVID19_Chile)**: Datos CoVID-19 actualizados Chile y [Latinoamerica](https://github.com/DataScienceResearchPeru/covid-19_latinoamerica).
+ 6.  **[Cuarentenas](https://docs.google.com/spreadsheets/d/1IjirW9zoW5H-x8AnQcQaKXZXiS1tCuTs0PxSkNxYE0g/edit#gid=0)**: Planilla resumen cuarentenas y cordones sanitarios en Chile.
 


### PR DESCRIPTION
Agregué un link a datos que estoy recopilando en una planilla. En particular son datos de inicio de síntomas diarios que creo que pueden ser útiles para calibrar modelos. Los datos los estoy obteniendo con técnicas de visión computacional desde un gráfico como este que publica el Minsal de vez en cuando. 

![Screen Shot 2020-05-18 at 16 39 27](https://user-images.githubusercontent.com/15633182/82257540-367a1980-9926-11ea-93d0-0bb74109214f.png)

La planilla contiene los datos obtenidos automáticamente para cada uno de los reportes que incluyeron ese gráfico. No he visto estos datos en otro repo por eso me pareció importante poner el link. Si hubiese interés podría pasar los datos a un csv y agregarlo acá (pero descargarlos de la planilla debiera ser trivial). 

Adicionalmente la planilla contiene datos de la encuesta de la Sochimi respecto de uso de UCI/UTI y VMIs.